### PR TITLE
Added a new config-variable: ignoreAdventureMode. When set to true pl…

### DIFF
--- a/OneWayElytra.iml
+++ b/OneWayElytra.iml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="4">
-  <component name="AdditionalModuleElements">
-    <content url="file://$MODULE_DIR$" dumb="true">
-      <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
-    </content>
-  </component>
   <component name="FacetManager">
     <facet type="minecraft" name="Minecraft">
       <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.philippstamp.onewayelytra</groupId>
     <artifactId>OneWayElytra</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <packaging>jar</packaging>
 
     <name>OneWayElytra</name>

--- a/src/main/java/de/philippstamp/oneWayElytra/listeners/OneWayElytraListener.java
+++ b/src/main/java/de/philippstamp/oneWayElytra/listeners/OneWayElytraListener.java
@@ -39,7 +39,7 @@ public class OneWayElytraListener implements Listener {
         if(world != null) {
             Bukkit.getScheduler().runTaskTimer(oneWayElytra, () -> {
                 Bukkit.getWorld(oneWayElytra.getFm().getConfig().getString("location.world")).getPlayers().forEach(player -> {
-                    if (player.getGameMode() == GameMode.SURVIVAL) {
+                    if (player.getGameMode() == GameMode.SURVIVAL || player.getGameMode() == GameMode.ADVENTURE ){
                         player.setAllowFlight(playerInRadius(player));
                         if (playersFlying.contains(player) && !player.getLocation().getBlock().getRelative(BlockFace.DOWN).getType().isAir()) {
                             player.setAllowFlight(false);

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: OneWayElytra
-version: '1.0.2'
+version: '1.0.3'
 main: de.philippstamp.oneWayElytra.OneWayElytra
 author: JuggleGaming
 api-version: '1.21.4'


### PR DESCRIPTION
players in adventuremode can not fly into the air. Please add it manually if it does not work properly. A new config-system will get added later.