### PR TITLE
Update 1.1.2 (MC: 26.1.2)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,6 @@
+## Version: 1.1.2
+
+- Added changelog-system
+- Fixed an error occurring when worldguard is not installed
+- Changed how the worldguard hook is working
+- added an indicator, showing if worldguard is installed

--- a/pom.xml
+++ b/pom.xml
@@ -81,13 +81,13 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>26.1-R0.1-SNAPSHOT</version>
+            <version>26.1.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.sk89q.worldguard</groupId>
             <artifactId>worldguard-bukkit</artifactId>
-            <version>7.0.15</version>
+            <version>7.0.16</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/de/jugglegaming/oneWayElytra/OneWayElytra.java
+++ b/src/main/java/de/jugglegaming/oneWayElytra/OneWayElytra.java
@@ -32,6 +32,8 @@ public final class OneWayElytra extends JavaPlugin {
     private WorldguardFlags wgFlag;
     private WorldguardHook worldguardHook;
 
+    private boolean isWorldguardInstalled;
+
     @Override
     public void onLoad() {
         connectToWorldguard();
@@ -53,7 +55,12 @@ public final class OneWayElytra extends JavaPlugin {
         ccs.sendMessage(prefix + "Listeners successfully registered!");
         registerCommands();
         ccs.sendMessage(prefix + "Commands successfully registered!");
-
+        isWorldguardInstalled = WorldguardUtils.isWorldGuardInstalled();
+        if(isWorldguardInstalled) {
+            ccs.sendMessage(prefix + "WorldGuard: connected");
+        } else {
+            ccs.sendMessage(prefix + "WorldGuard: not found");
+        }
         ccs.sendMessage(prefix + "*~*~*~*~*~*~*~* <<OneWayElytra>> *~*~*~*~*~*~*~*");
         ccs.sendMessage(prefix + "Plugin successfully loaded!");
         ccs.sendMessage(prefix + "Version: " + getDescription().getVersion());

--- a/src/main/java/de/jugglegaming/oneWayElytra/OneWayElytra.java
+++ b/src/main/java/de/jugglegaming/oneWayElytra/OneWayElytra.java
@@ -6,6 +6,7 @@ import de.jugglegaming.oneWayElytra.managers.FileManager;
 import de.jugglegaming.oneWayElytra.managers.RadiusManager;
 import de.jugglegaming.oneWayElytra.utils.Tools;
 import de.jugglegaming.oneWayElytra.utils.WorldguardFlags;
+import de.jugglegaming.oneWayElytra.utils.WorldguardHook;
 import de.jugglegaming.oneWayElytra.utils.WorldguardUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.command.ConsoleCommandSender;
@@ -29,6 +30,7 @@ public final class OneWayElytra extends JavaPlugin {
     private OneWayElytraListener oneWayElytraListener;
 
     private WorldguardFlags wgFlag;
+    private WorldguardHook worldguardHook;
 
     @Override
     public void onLoad() {
@@ -79,7 +81,7 @@ public final class OneWayElytra extends JavaPlugin {
 
     @EventHandler
     public void registerListener() {
-        oneWayElytraListener = new OneWayElytraListener(this);
+        oneWayElytraListener = new OneWayElytraListener(this, worldguardHook);
         pluginManager.registerEvents(oneWayElytraListener, this);
     }
 
@@ -93,6 +95,7 @@ public final class OneWayElytra extends JavaPlugin {
         Plugin worldGuard = pluginManager.getPlugin("WorldGuard");
         if(WorldguardUtils.isWorldGuardInstalled()){
             WorldguardFlags.load();
+            worldguardHook = new WorldguardHook();
             ccs.sendMessage("[OneWayElytra] Successfully connected to WorldGuard!");
         } else {
             ccs.sendMessage("[OneWayElytra] Worldguard not found.");

--- a/src/main/java/de/jugglegaming/oneWayElytra/listeners/OneWayElytraListener.java
+++ b/src/main/java/de/jugglegaming/oneWayElytra/listeners/OneWayElytraListener.java
@@ -1,16 +1,8 @@
 package de.jugglegaming.oneWayElytra.listeners;
 
-import com.sk89q.worldedit.bukkit.BukkitAdapter;
-import com.sk89q.worldguard.LocalPlayer;
-import com.sk89q.worldguard.WorldGuard;
-import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
-import com.sk89q.worldguard.protection.ApplicableRegionSet;
-import com.sk89q.worldguard.protection.regions.RegionContainer;
-import com.sk89q.worldguard.protection.regions.RegionQuery;
 import de.jugglegaming.oneWayElytra.OneWayElytra;
 import de.jugglegaming.oneWayElytra.utils.ActionBar;
-import de.jugglegaming.oneWayElytra.utils.WorldguardFlags;
-import de.jugglegaming.oneWayElytra.utils.WorldguardUtils;
+import de.jugglegaming.oneWayElytra.utils.WorldguardHook;
 import org.bukkit.*;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.EntityType;
@@ -35,46 +27,69 @@ public class OneWayElytraListener implements Listener {
     private List<Location> positions = new ArrayList<>();
 
     private OneWayElytra oneWayElytra;
+    private WorldguardHook worldguardHook;
 
-    public OneWayElytraListener(OneWayElytra oneWayElytra){
+    public OneWayElytraListener(OneWayElytra oneWayElytra, WorldguardHook worldguardHook) {
         this.oneWayElytra = oneWayElytra;
+        this.worldguardHook = worldguardHook;
         this.radius = oneWayElytra.getFileManager().getConfig().getInt("radius");
         Bukkit.getScheduler().runTaskTimer(oneWayElytra, () -> {
 
             for (Player player : Bukkit.getOnlinePlayers()) {
-                if(WorldguardUtils.isWorldGuardInstalled()){
 
-                    com.sk89q.worldedit.util.Location loc = BukkitAdapter.adapt(player.getLocation());
-                    RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
-                    RegionQuery query = container.createQuery();
-                    ApplicableRegionSet set = query.getApplicableRegions(loc);
-                    LocalPlayer localPlayer = WorldGuardPlugin.inst().wrapPlayer(player);
+                boolean wgAllowed = false;
 
-                    boolean wgAllowed = set.testState(localPlayer, WorldguardFlags.ONEWAYELYTRA);
-                    boolean inRadiusArea = oneWayElytra.getRadiusManager().isInAnyArea(player.getLocation());
-
-                    if ((wgAllowed || inRadiusArea) && !playersFlying.contains(player) && player.isOnGround()) {
-                        if(player.getGameMode() == GameMode.SURVIVAL || player.getGameMode() == GameMode.ADVENTURE && oneWayElytra.getFileManager().getConfig().getBoolean("adventure")) {
-                            player.setAllowFlight(true);
-                        }
-                    }
-
+                if (worldguardHook != null) {
+                    wgAllowed = worldguardHook.canFly(player);
                 }
 
-                if (player.getGameMode() == GameMode.SURVIVAL || player.getGameMode() == GameMode.ADVENTURE) {
+                boolean inRadiusArea =
+                        oneWayElytra.getRadiusManager()
+                                .isInAnyArea(player.getLocation());
+
+                if ((wgAllowed || inRadiusArea)
+                        && !playersFlying.contains(player)
+                        && player.isOnGround()) {
+
+                    if (player.getGameMode() == GameMode.SURVIVAL
+                            || (player.getGameMode() == GameMode.ADVENTURE
+                            && oneWayElytra.getFileManager()
+                            .getConfig()
+                            .getBoolean("adventure"))) {
+
+                        player.setAllowFlight(true);
+                    }
+                }
+
+                if (!(wgAllowed || inRadiusArea) && !playersFlying.contains(player)) {
+                    player.setAllowFlight(false);
+                }
+
+                if (player.getGameMode() == GameMode.SURVIVAL
+                        || player.getGameMode() == GameMode.ADVENTURE) {
+
                     if (playersFlying.contains(player)
-                            && !player.getLocation().getBlock().getRelative(BlockFace.DOWN).getType().isAir()) {
+                            && !player.getLocation()
+                            .getBlock()
+                            .getRelative(BlockFace.DOWN)
+                            .getType()
+                            .isAir()) {
 
                         player.setGliding(false);
                         playersBoosted.remove(player);
 
-                        Bukkit.getScheduler().runTaskLater(oneWayElytra, () -> {
-                            playersFlying.remove(player);
-                            player.setAllowFlight(false);
-                        }, 5);
+                        Bukkit.getScheduler().runTaskLater(
+                                oneWayElytra,
+                                () -> {
+                                    playersFlying.remove(player);
+                                    player.setAllowFlight(false);
+                                },
+                                5
+                        );
                     }
                 }
             }
+
         }, 0, 3);
     }
 
@@ -99,20 +114,16 @@ public class OneWayElytraListener implements Listener {
 
     public boolean isAllowedToFly(Player player) {
         boolean wgAllowed = false;
-        if (WorldguardUtils.isWorldGuardInstalled()) {
-            com.sk89q.worldedit.util.Location loc = BukkitAdapter.adapt(player.getLocation());
-            RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
-            RegionQuery query = container.createQuery();
-            ApplicableRegionSet set = query.getApplicableRegions(loc);
-            LocalPlayer localPlayer = WorldGuardPlugin.inst().wrapPlayer(player);
-
-            wgAllowed = set.testState(localPlayer, WorldguardFlags.ONEWAYELYTRA);
+        if (worldguardHook != null) {
+            wgAllowed = worldguardHook.canFly(player);
         }
 
-        boolean inRadiusArea = oneWayElytra.getRadiusManager().isInAnyArea(player.getLocation());
-
+        boolean inRadiusArea =
+                oneWayElytra.getRadiusManager()
+                        .isInAnyArea(player.getLocation());
         return wgAllowed || inRadiusArea;
     }
+
 
     @EventHandler
     public void onEntityDamage(EntityDamageEvent event){

--- a/src/main/java/de/jugglegaming/oneWayElytra/utils/WorldguardHook.java
+++ b/src/main/java/de/jugglegaming/oneWayElytra/utils/WorldguardHook.java
@@ -1,0 +1,38 @@
+package de.jugglegaming.oneWayElytra.utils;
+
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldguard.LocalPlayer;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.protection.regions.RegionContainer;
+import com.sk89q.worldguard.protection.regions.RegionQuery;
+import org.bukkit.entity.Player;
+
+public class WorldguardHook {
+
+    public boolean canFly(Player player) {
+
+        com.sk89q.worldedit.util.Location loc =
+                BukkitAdapter.adapt(player.getLocation());
+
+        RegionContainer container =
+                WorldGuard.getInstance()
+                        .getPlatform()
+                        .getRegionContainer();
+
+        RegionQuery query = container.createQuery();
+
+        ApplicableRegionSet set =
+                query.getApplicableRegions(loc);
+
+        LocalPlayer localPlayer =
+                WorldGuardPlugin.inst().wrapPlayer(player);
+
+        return set.testState(
+                localPlayer,
+                WorldguardFlags.ONEWAYELYTRA
+        );
+    }
+
+}


### PR DESCRIPTION
Changing how to handle the worldguard-webhook to fix an error occurring when starting the server without worldguard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WorldGuard region flag now controls when players can use elytra flight.
  * Adds detection/indicator for whether WorldGuard is installed and adapts behavior accordingly.

* **Bug Fixes**
  * Prevents errors when WorldGuard is not present by falling back to non-WorldGuard behavior.

* **Chores**
  * Updated Spigot API and WorldGuard library versions.
* **Documentation**
  * Added changelog entry for v1.1.2.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JuggleGaming/OneWayElytra/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->