### PR TITLE
Elytra item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 ### New features
-- Added changelog-system
-- Fixed an error occurring when worldguard is not installed
-- Changed how the worldguard hook is working
-- added an indicator, showing if worldguard is installed
+- Added the ability to use 
+
+### This is a beta version! Do not use in production!
+This beta features the first tests for the new owe-item. To be able to test the new Item just use `/owe tag add` to add the tag to an item, that is inside your chestplate slot. When the tag is added, you can fly into the air where ever you want. This item can be given to other players. Atm it isn't possible to set a tag for another player. This Command ist mostly for testing and might be removed at a later state. With `/owe tag remove` the tag can be removed again. This command applies to the executors chestplate-slot only.
+
+To disable the ability to start flying everywhere you can set the worldguard-flag `OWE-ITEM` to `false`. To deny entry into an area while using your owe set the flag `OWE-ENTRY` to `false`.
+
+## Breaking changes
+The worldguard-flag to enable the ability to fly without an owe-item (as before) has been renamed to `OWE-START` (before: `ONEWAYELYTRA`). Please check wether this results any issues and if you have to change the flag.
 
 ### Information
 Worldguard version needed: 7.0.16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### New features
-- Added the ability to use a custom tagged chestplate-item as a owe.
+- Added the ability to use a custom tagged chestplate-item as an owe.
 
 ### This is a beta version! Do not use in production!
 This beta features the first tests for the new owe-item. To be able to test the new Item just use `/owe tag add` to add the tag to an item, that is inside your chestplate slot. When the tag is added, you can fly into the air where ever you want. This item can be given to other players. Atm it isn't possible to set a tag for another player. This Command ist mostly for testing and might be removed at a later state. With `/owe tag remove` the tag can be removed again. This command applies to the executors chestplate-slot only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### New features
-- Added the ability to use 
+- Added the ability to use a custom tagged chestplate-item as a owe.
 
 ### This is a beta version! Do not use in production!
 This beta features the first tests for the new owe-item. To be able to test the new Item just use `/owe tag add` to add the tag to an item, that is inside your chestplate slot. When the tag is added, you can fly into the air where ever you want. This item can be given to other players. Atm it isn't possible to set a tag for another player. This Command ist mostly for testing and might be removed at a later state. With `/owe tag remove` the tag can be removed again. This command applies to the executors chestplate-slot only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 - Added the ability to use a custom tagged chestplate-item as an owe.
 
 ### This is a beta version! Do not use in production!
-This beta features the first tests for the new owe-item. To be able to test the new Item just use `/owe tag add` to add the tag to an item, that is inside your chestplate slot. When the tag is added, you can fly into the air where ever you want. This item can be given to other players. Atm it isn't possible to set a tag for another player. This Command ist mostly for testing and might be removed at a later state. With `/owe tag remove` the tag can be removed again. This command applies to the executors chestplate-slot only.
+This beta features the first tests for the new owe-item. To be able to test the new Item just use `/owe tag add` to add the tag to an item, that is inside your chestplate slot. When the tag is added, you can fly into the air wherever you want. This item can be given to other players. Currently it isn't possible to set a tag for another player. This Command ist mostly for testing and might be removed at a later state. With `/owe tag remove` the tag can be removed again. This command applies to the executors chestplate-slot only.
 
 To disable the ability to start flying everywhere you can set the worldguard-flag `OWE-ITEM` to `false`. To deny entry into an area while using your owe set the flag `OWE-ENTRY` to `false`.
 
 ## Breaking changes
-The worldguard-flag to enable the ability to fly without an owe-item (as before) has been renamed to `OWE-START` (before: `ONEWAYELYTRA`). Please check wether this results any issues and if you have to change the flag.
+The worldguard-flag to enable the ability to fly without an owe-item (as before) has been renamed to `OWE-START` (before: `ONEWAYELYTRA`). Please check whether this results any issues and if you have to change the flag.
 
 ### Information
-Worldguard version needed: 7.0.16
+Worldguard version needed: 7.0.17

--- a/README.md
+++ b/README.md
@@ -52,6 +52,4 @@ adventure: true
 
 locations: {}
 ```
-
-
 </details>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.philippstamp.onewayelytra</groupId>
     <artifactId>OneWayElytra</artifactId>
-    <version>1.1.2</version>
+    <version>1.2.0-beta1</version>
     <packaging>jar</packaging>
 
     <name>OneWayElytra</name>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,6 @@
             </resource>
         </resources>
     </build>
-
     <repositories>
         <repository>
             <id>spigotmc-repo</id>
@@ -87,7 +86,7 @@
         <dependency>
             <groupId>com.sk89q.worldguard</groupId>
             <artifactId>worldguard-bukkit</artifactId>
-            <version>7.0.16</version>
+            <version>7.0.17</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/de/jugglegaming/oneWayElytra/OneWayElytra.java
+++ b/src/main/java/de/jugglegaming/oneWayElytra/OneWayElytra.java
@@ -1,6 +1,7 @@
 package de.jugglegaming.oneWayElytra;
 
-import de.jugglegaming.oneWayElytra.commands.OneWayElytraCMD;
+import de.jugglegaming.oneWayElytra.commands.OneWayElytraCommand;
+import de.jugglegaming.oneWayElytra.listeners.ElytraItemListener;
 import de.jugglegaming.oneWayElytra.listeners.OneWayElytraListener;
 import de.jugglegaming.oneWayElytra.managers.FileManager;
 import de.jugglegaming.oneWayElytra.managers.RadiusManager;
@@ -28,6 +29,7 @@ public final class OneWayElytra extends JavaPlugin {
     public ConsoleCommandSender ccs = Bukkit.getServer().getConsoleSender();
 
     private OneWayElytraListener oneWayElytraListener;
+    private ElytraItemListener elytraItemListener;
 
     private WorldguardFlags wgFlag;
     private WorldguardHook worldguardHook;
@@ -90,12 +92,14 @@ public final class OneWayElytra extends JavaPlugin {
     public void registerListener() {
         oneWayElytraListener = new OneWayElytraListener(this, worldguardHook);
         pluginManager.registerEvents(oneWayElytraListener, this);
+        elytraItemListener = new ElytraItemListener(this);
+        pluginManager.registerEvents(elytraItemListener, this);
     }
 
     @EventHandler
     public void registerCommands() {
         //Objects.requireNonNull(getCommand("onewayelytra")).setExecutor(new OneWayElytraCMD(Instance));
-        getCommand("onewayelytra").setExecutor(new OneWayElytraCMD(Instance, oneWayElytraListener));
+        getCommand("onewayelytra").setExecutor(new OneWayElytraCommand(Instance, oneWayElytraListener));
     }
 
     public void connectToWorldguard(){

--- a/src/main/java/de/jugglegaming/oneWayElytra/commands/OneWayElytraCommand.java
+++ b/src/main/java/de/jugglegaming/oneWayElytra/commands/OneWayElytraCommand.java
@@ -26,34 +26,34 @@ public class OneWayElytraCommand implements CommandExecutor {
             if(player.hasPermission("onewayelytra.command")){
                 if(args.length == 5) {
                     // /onewayelytra location <set> [name] <radius> [number]
-                   if(args[0].equalsIgnoreCase("location")){
-                       if(args[1].equalsIgnoreCase("set")){
-                           String locationName = args[2];
-                           if(oneWayElytra.getFileManager().getConfig().getSection("locations").contains(locationName)) {
-                               if (args[3].equalsIgnoreCase("radius")){
-                                   try {
-                                       int radius = Integer.parseInt(args[4]);
-                                       if(radius >= 0){
-                                           oneWayElytra.getFileManager().getConfig().set("locations." + locationName + ".radius", radius);
-                                           oneWayElytra.getFileManager().saveConfig();
-                                           player.sendMessage(oneWayElytra.prefix + oneWayElytra.getTools().replaceVariables(oneWayElytra.getFileManager().getMessages().getString("radiusSet"), Integer.valueOf(args[4]), locationName));
-                                           oneWayElytra.getRadiusManager().loadAreas(oneWayElytra.getFileManager().getConfig());
-                                       } else {
-                                           sender.sendMessage(oneWayElytra.prefix + oneWayElytra.getTools().replaceVariables(oneWayElytra.getFileManager().getMessages().getString("valueMustBeHigherOrEqual")));
-                                       }
-                                   } catch(NumberFormatException e){
-                                       sender.sendMessage(oneWayElytra.prefix + oneWayElytra.getTools().replaceVariables(oneWayElytra.getFileManager().getMessages().getString("valueMustBeInt")));
-                                   }
-                               }
-                           } else {
-                               player.sendMessage(oneWayElytra.prefix + oneWayElytra.getTools().replaceVariables(oneWayElytra.getFileManager().getMessages().getString("locationNotFound")));
-                           }
-                       } else {
-                           player.sendMessage(oneWayElytra.prefix + oneWayElytra.getTools().replaceVariables(oneWayElytra.getFileManager().getMessages().getString("wrongArgs")));
-                       }
-                   } else {
-                       player.sendMessage(oneWayElytra.prefix + oneWayElytra.getTools().replaceVariables(oneWayElytra.getFileManager().getMessages().getString("wrongArgs")));
-                   }
+                    if(args[0].equalsIgnoreCase("location")){
+                        if(args[1].equalsIgnoreCase("set")){
+                            String locationName = args[2];
+                            if(oneWayElytra.getFileManager().getConfig().getSection("locations").contains(locationName)) {
+                                if (args[3].equalsIgnoreCase("radius")){
+                                    try {
+                                        int radius = Integer.parseInt(args[4]);
+                                        if(radius >= 0){
+                                            oneWayElytra.getFileManager().getConfig().set("locations." + locationName + ".radius", radius);
+                                            oneWayElytra.getFileManager().saveConfig();
+                                            player.sendMessage(oneWayElytra.prefix + oneWayElytra.getTools().replaceVariables(oneWayElytra.getFileManager().getMessages().getString("radiusSet"), Integer.valueOf(args[4]), locationName));
+                                            oneWayElytra.getRadiusManager().loadAreas(oneWayElytra.getFileManager().getConfig());
+                                        } else {
+                                            sender.sendMessage(oneWayElytra.prefix + oneWayElytra.getTools().replaceVariables(oneWayElytra.getFileManager().getMessages().getString("valueMustBeHigherOrEqual")));
+                                        }
+                                    } catch(NumberFormatException e){
+                                        sender.sendMessage(oneWayElytra.prefix + oneWayElytra.getTools().replaceVariables(oneWayElytra.getFileManager().getMessages().getString("valueMustBeInt")));
+                                    }
+                                }
+                            } else {
+                                player.sendMessage(oneWayElytra.prefix + oneWayElytra.getTools().replaceVariables(oneWayElytra.getFileManager().getMessages().getString("locationNotFound")));
+                            }
+                        } else {
+                            player.sendMessage(oneWayElytra.prefix + oneWayElytra.getTools().replaceVariables(oneWayElytra.getFileManager().getMessages().getString("wrongArgs")));
+                        }
+                    } else {
+                        player.sendMessage(oneWayElytra.prefix + oneWayElytra.getTools().replaceVariables(oneWayElytra.getFileManager().getMessages().getString("wrongArgs")));
+                    }
                 }
                 if(args.length == 4) {
                     player.sendMessage(oneWayElytra.prefix + oneWayElytra.getTools().replaceVariables(oneWayElytra.getFileManager().getMessages().getString("wrongArgs")));
@@ -121,7 +121,7 @@ public class OneWayElytraCommand implements CommandExecutor {
                                 ItemMeta meta = itemStack.getItemMeta();
                                 PersistentDataContainer dataContainer = meta.getPersistentDataContainer();
                                 NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
-                                dataContainer.set(key, PersistentDataType.STRING, "true");
+                                dataContainer.set(key, PersistentDataType.BYTE, (byte) 1);
                                 itemStack.setItemMeta(meta);
                                 player.sendMessage("Successfully added tag");
                             }
@@ -141,9 +141,9 @@ public class OneWayElytraCommand implements CommandExecutor {
                                 player.sendMessage(dataContainer.toString());
                             }
                         }
-                        } else {
-                            player.sendMessage(oneWayElytra.prefix + oneWayElytra.getTools().replaceVariables(oneWayElytra.getFileManager().getMessages().getString("wrongArgs")));
-                        }
+                    } else {
+                        player.sendMessage(oneWayElytra.prefix + oneWayElytra.getTools().replaceVariables(oneWayElytra.getFileManager().getMessages().getString("wrongArgs")));
+                    }
                 }
                 if (args.length == 1){
                     player.sendMessage(oneWayElytra.prefix + oneWayElytra.getTools().replaceVariables(oneWayElytra.getFileManager().getMessages().getString("wrongArgs")));

--- a/src/main/java/de/jugglegaming/oneWayElytra/commands/OneWayElytraCommand.java
+++ b/src/main/java/de/jugglegaming/oneWayElytra/commands/OneWayElytraCommand.java
@@ -2,10 +2,15 @@ package de.jugglegaming.oneWayElytra.commands;
 
 import de.jugglegaming.oneWayElytra.OneWayElytra;
 import de.jugglegaming.oneWayElytra.listeners.OneWayElytraListener;
+import org.bukkit.NamespacedKey;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
 
 public class OneWayElytraCommand implements CommandExecutor {
 
@@ -109,9 +114,36 @@ public class OneWayElytraCommand implements CommandExecutor {
                         } else {
                             player.sendMessage(oneWayElytra.prefix + oneWayElytra.getTools().replaceVariables(oneWayElytra.getFileManager().getMessages().getString("wrongArgs")));
                         }
-                    } else {
-                        player.sendMessage(oneWayElytra.prefix + oneWayElytra.getTools().replaceVariables(oneWayElytra.getFileManager().getMessages().getString("wrongArgs")));
-                    }
+                    } else if (args[0].equalsIgnoreCase("tag")){
+                        if (args[1].equalsIgnoreCase("add")){
+                            if(player.getInventory().getChestplate() != null){
+                                ItemStack itemStack = player.getInventory().getChestplate();
+                                ItemMeta meta = itemStack.getItemMeta();
+                                PersistentDataContainer dataContainer = meta.getPersistentDataContainer();
+                                NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
+                                dataContainer.set(key, PersistentDataType.STRING, "true");
+                                itemStack.setItemMeta(meta);
+                                player.sendMessage("Successfully added tag");
+                            }
+                        } else if (args[1].equalsIgnoreCase("remove")){
+                            ItemStack itemStack = player.getInventory().getChestplate();
+                            ItemMeta meta = itemStack.getItemMeta();
+                            PersistentDataContainer dataContainer = meta.getPersistentDataContainer();
+                            NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
+                            dataContainer.remove(key);
+                            itemStack.setItemMeta(meta);
+                            player.sendMessage("Successfully removed tag");
+                        } else if(args[1].equalsIgnoreCase("info")){
+                            if(player.getInventory().getChestplate() != null){
+                                ItemStack itemStack = player.getInventory().getChestplate();
+                                ItemMeta meta = itemStack.getItemMeta();
+                                PersistentDataContainer dataContainer = meta.getPersistentDataContainer();
+                                player.sendMessage(dataContainer.toString());
+                            }
+                        }
+                        } else {
+                            player.sendMessage(oneWayElytra.prefix + oneWayElytra.getTools().replaceVariables(oneWayElytra.getFileManager().getMessages().getString("wrongArgs")));
+                        }
                 }
                 if (args.length == 1){
                     player.sendMessage(oneWayElytra.prefix + oneWayElytra.getTools().replaceVariables(oneWayElytra.getFileManager().getMessages().getString("wrongArgs")));

--- a/src/main/java/de/jugglegaming/oneWayElytra/commands/OneWayElytraCommand.java
+++ b/src/main/java/de/jugglegaming/oneWayElytra/commands/OneWayElytraCommand.java
@@ -6,14 +6,13 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.PluginDescriptionFile;
 
-public class OneWayElytraCMD implements CommandExecutor {
+public class OneWayElytraCommand implements CommandExecutor {
 
     private OneWayElytra oneWayElytra;
     private OneWayElytraListener oneWayElytraListener;
 
-    public OneWayElytraCMD(OneWayElytra oneWayElytra, OneWayElytraListener oneWayElytraListener) {
+    public OneWayElytraCommand(OneWayElytra oneWayElytra, OneWayElytraListener oneWayElytraListener) {
         this.oneWayElytra = oneWayElytra;
         this.oneWayElytraListener = oneWayElytraListener;
     }

--- a/src/main/java/de/jugglegaming/oneWayElytra/commands/OneWayElytraCommand.java
+++ b/src/main/java/de/jugglegaming/oneWayElytra/commands/OneWayElytraCommand.java
@@ -115,6 +115,7 @@ public class OneWayElytraCommand implements CommandExecutor {
                             player.sendMessage(oneWayElytra.prefix + oneWayElytra.getTools().replaceVariables(oneWayElytra.getFileManager().getMessages().getString("wrongArgs")));
                         }
                     } else if (args[0].equalsIgnoreCase("tag")){
+                        //TODO: REMOVE COMMAND IF NEEDED AND FIND ANOTHER SOLUTION
                         if (args[1].equalsIgnoreCase("add")){
                             if(player.getInventory().getChestplate() != null){
                                 ItemStack itemStack = player.getInventory().getChestplate();

--- a/src/main/java/de/jugglegaming/oneWayElytra/commands/OneWayElytraCommand.java
+++ b/src/main/java/de/jugglegaming/oneWayElytra/commands/OneWayElytraCommand.java
@@ -128,6 +128,10 @@ public class OneWayElytraCommand implements CommandExecutor {
                             }
                         } else if (args[1].equalsIgnoreCase("remove")){
                             ItemStack itemStack = player.getInventory().getChestplate();
+                            if (itemStack == null || !itemStack.hasItemMeta()) {
+                                player.sendMessage(oneWayElytra.prefix + "No tagged chestplate equipped.");
+                                return false;
+                            }
                             ItemMeta meta = itemStack.getItemMeta();
                             PersistentDataContainer dataContainer = meta.getPersistentDataContainer();
                             NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");

--- a/src/main/java/de/jugglegaming/oneWayElytra/listeners/ElytraItemListener.java
+++ b/src/main/java/de/jugglegaming/oneWayElytra/listeners/ElytraItemListener.java
@@ -17,31 +17,9 @@ public class ElytraItemListener implements Listener {
     private OneWayElytra oneWayElytra;
     public ElytraItemListener(OneWayElytra oneWayElytra) {
         this.oneWayElytra = oneWayElytra;
-    }
-
-    @EventHandler
-    public void onToggleFlight(PlayerToggleFlightEvent event){
-        Player player = event.getPlayer();
-        //TODO: SURVIVAL AND ADVENTURE MODE ONLY
-        if(player.getGameMode().equals(GameMode.SURVIVAL) || player.getGameMode().equals(GameMode.ADVENTURE)){
-            if(player.getInventory().getChestplate() != null){
-                ItemStack itemStack = player.getInventory().getChestplate();
-                ItemMeta meta = itemStack.getItemMeta();
-                PersistentDataContainer dataContainer = meta.getPersistentDataContainer();
-                NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
-                if (dataContainer.has(key, PersistentDataType.STRING)) {
-                    player.sendMessage("JO");
-                } else {
-                    player.sendMessage("NOPE");
-                }
-            } else {
-                player.sendMessage("NO CHESTPLATE");
-            }
-        } else {
-            player.sendMessage("WRONG GAMEMODE");
-        }
-
 
     }
+
+
 
 }

--- a/src/main/java/de/jugglegaming/oneWayElytra/listeners/ElytraItemListener.java
+++ b/src/main/java/de/jugglegaming/oneWayElytra/listeners/ElytraItemListener.java
@@ -1,0 +1,47 @@
+package de.jugglegaming.oneWayElytra.listeners;
+
+import de.jugglegaming.oneWayElytra.OneWayElytra;
+import org.bukkit.GameMode;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerToggleFlightEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+public class ElytraItemListener implements Listener {
+
+    private OneWayElytra oneWayElytra;
+    public ElytraItemListener(OneWayElytra oneWayElytra) {
+        this.oneWayElytra = oneWayElytra;
+    }
+
+    @EventHandler
+    public void onToggleFlight(PlayerToggleFlightEvent event){
+        Player player = event.getPlayer();
+        //TODO: SURVIVAL AND ADVENTURE MODE ONLY
+        if(player.getGameMode().equals(GameMode.SURVIVAL) || player.getGameMode().equals(GameMode.ADVENTURE)){
+            if(player.getInventory().getChestplate() != null){
+                ItemStack itemStack = player.getInventory().getChestplate();
+                ItemMeta meta = itemStack.getItemMeta();
+                PersistentDataContainer dataContainer = meta.getPersistentDataContainer();
+                NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
+                if (dataContainer.has(key, PersistentDataType.STRING)) {
+                    player.sendMessage("JO");
+                } else {
+                    player.sendMessage("NOPE");
+                }
+            } else {
+                player.sendMessage("NO CHESTPLATE");
+            }
+        } else {
+            player.sendMessage("WRONG GAMEMODE");
+        }
+
+
+    }
+
+}

--- a/src/main/java/de/jugglegaming/oneWayElytra/listeners/OneWayElytraListener.java
+++ b/src/main/java/de/jugglegaming/oneWayElytra/listeners/OneWayElytraListener.java
@@ -145,8 +145,7 @@ public class OneWayElytraListener implements Listener {
             player.setVelocity(new Vector(0, 0, 0));
 
             event.setTo(from);
-            //TODO: MESSAGE STRING
-            ActionBar.send(player, "§cDu darfst hier nicht hineinfliegen!");
+            ActionBar.send(player, oneWayElytra.getTools().replaceVariables(oneWayElytra.getFileManager().getMessages().getString("areaEntryNotAllowed")));
         }
         if (playersFalling.contains(player) && player.isOnGround()) {
             ItemStack chestplate = player.getInventory().getChestplate();

--- a/src/main/java/de/jugglegaming/oneWayElytra/listeners/OneWayElytraListener.java
+++ b/src/main/java/de/jugglegaming/oneWayElytra/listeners/OneWayElytraListener.java
@@ -12,6 +12,8 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityToggleGlideEvent;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.*;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -51,7 +53,17 @@ public class OneWayElytraListener implements Listener {
                         oneWayElytra.getRadiusManager()
                                 .isInAnyArea(player.getLocation());
 
-                if ((wgAllowed || inRadiusArea)
+                boolean hasTaggedElytra = false;
+                ItemStack chestplate = player.getInventory().getChestplate();
+                if (chestplate != null && chestplate.hasItemMeta()) {
+                    PersistentDataContainer container = chestplate.getItemMeta().getPersistentDataContainer();
+                    NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
+                    if (container.has(key, PersistentDataType.BYTE)) {
+                        hasTaggedElytra = true;
+                    }
+                }
+
+                if (isAllowedToFly(player)
                         && !playersFlying.contains(player)
                         && player.isOnGround()) {
 
@@ -64,21 +76,8 @@ public class OneWayElytraListener implements Listener {
                         player.setAllowFlight(true);
                     }
                 }
-                if(player.getInventory().getChestplate() != null) {
-                    player.sendMessage("HAS CHESTPLATE");
-                    ItemStack itemStack = player.getInventory().getChestplate();
-                    ItemMeta meta = itemStack.getItemMeta();
-                    PersistentDataContainer dataContainer = meta.getPersistentDataContainer();
-                    NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
-                    if (dataContainer.has(key, PersistentDataType.STRING)) {
-                        player.sendMessage("JO");
-                        player.
-                    } else {
-                        player.sendMessage("NOPE");
-                    }
-                }
 
-                if (!(wgAllowed || inRadiusArea)
+                if (!(wgAllowed || inRadiusArea || hasTaggedElytra)
                         && !playersFlying.contains(player)
                         && (player.getGameMode() == GameMode.SURVIVAL
                         || player.getGameMode() == GameMode.ADVENTURE)) {
@@ -103,8 +102,15 @@ public class OneWayElytraListener implements Listener {
                                 () -> {
                                     playersFlying.remove(player);
                                     player.setAllowFlight(false);
-                                },
-                                5
+                                    ItemStack landingChest = player.getInventory().getChestplate();
+                                    if (landingChest != null && landingChest.hasItemMeta()) {
+                                        PersistentDataContainer container = landingChest.getItemMeta().getPersistentDataContainer();
+                                        NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
+                                        if (container.has(key, PersistentDataType.BYTE)) {
+                                            player.getInventory().setChestplate(null);
+                                        }
+                                    }
+                                },5
                         );
                     }
                 }
@@ -128,14 +134,12 @@ public class OneWayElytraListener implements Listener {
                 }, 1L);
             }
         }
-
-
     }
 
+    // TODO: REMOVE BEFORE RELEASE
     @EventHandler
     public void onElytraItem(PlayerToggleFlightEvent event){
         Player player = event.getPlayer();
-        //TODO: SURVIVAL AND ADVENTURE MODE ONLY
         if(player.getGameMode().equals(GameMode.CREATIVE)) {
             player.sendMessage("CREATIVE MODE");
         } else {
@@ -147,7 +151,7 @@ public class OneWayElytraListener implements Listener {
                 ItemMeta meta = itemStack.getItemMeta();
                 PersistentDataContainer dataContainer = meta.getPersistentDataContainer();
                 NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
-                if (dataContainer.has(key, PersistentDataType.STRING)) {
+                if (dataContainer.has(key, PersistentDataType.BYTE)) {
                     player.sendMessage("JO");
                 } else {
                     player.sendMessage("NOPE");
@@ -156,8 +160,6 @@ public class OneWayElytraListener implements Listener {
                 player.sendMessage("NO CHESTPLATE");
             }
         }
-
-
     }
 
     public boolean isAllowedToFly(Player player) {
@@ -165,10 +167,20 @@ public class OneWayElytraListener implements Listener {
         if (worldguardHook != null) {
             wgAllowed = worldguardHook.canFly(player);
         }
+        boolean inRadiusArea = oneWayElytra.getRadiusManager().isInAnyArea(player.getLocation());
+        boolean hasTaggedElytra = false;
 
-        boolean inRadiusArea =
-                oneWayElytra.getRadiusManager()
-                        .isInAnyArea(player.getLocation());
+        ItemStack chestplate = player.getInventory().getChestplate();
+
+        if (chestplate != null && chestplate.hasItemMeta()) {
+            PersistentDataContainer container = chestplate.getItemMeta().getPersistentDataContainer();
+            NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
+            if (container.has(key, PersistentDataType.BYTE)) {
+                hasTaggedElytra = true;
+            }
+        }
+
+        if (hasTaggedElytra) return true;
         return wgAllowed || inRadiusArea;
     }
 
@@ -221,6 +233,48 @@ public class OneWayElytraListener implements Listener {
         }
     }
 
+    //Deny interaction with chestplate if player is flying
+    @EventHandler
+    public void onPlayerInteract(PlayerInteractEvent event) {
+        Player player = event.getPlayer();
+        ItemStack chestplate = player.getInventory().getChestplate();
+        if(playersFlying.contains(player)){
+            if (chestplate != null && chestplate.hasItemMeta()) {
+                PersistentDataContainer container = chestplate.getItemMeta().getPersistentDataContainer();
+                NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
+                if (container.has(key, PersistentDataType.BYTE)) {
+                    event.setCancelled(true);
+                }
+            }
+        }
+    }
 
-
+    //Deny interaction with onewayelytra if player is flying
+    @EventHandler
+    public void onItemClick(InventoryClickEvent event){
+        if (!(event.getWhoClicked() instanceof Player)) return;
+        Player player = (Player) event.getWhoClicked();
+        if(playersFlying.contains(player)){
+            if (event.getSlotType() == InventoryType.SlotType.ARMOR) {
+                ItemStack current = event.getCurrentItem();
+                if (current != null && current.hasItemMeta()) {
+                    PersistentDataContainer container = current.getItemMeta().getPersistentDataContainer();
+                    NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
+                    if (container.has(key, PersistentDataType.BYTE)) {
+                        event.setCancelled(true);
+                    }
+                }
+            }
+            if (event.isShiftClick()) {
+                ItemStack current = event.getCurrentItem();
+                if (current != null && current.hasItemMeta()) {
+                    PersistentDataContainer container = current.getItemMeta().getPersistentDataContainer();
+                    NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
+                    if (container.has(key, PersistentDataType.BYTE)) {
+                        event.setCancelled(true);
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/main/java/de/jugglegaming/oneWayElytra/listeners/OneWayElytraListener.java
+++ b/src/main/java/de/jugglegaming/oneWayElytra/listeners/OneWayElytraListener.java
@@ -28,6 +28,7 @@ public class OneWayElytraListener implements Listener {
     private int radius;
     private int boostMultiplier;
     private List<Player> playersFlying = new ArrayList<>();
+    private List<Player> playersFalling = new ArrayList<>();
     private List<Player> playersBoosted = new ArrayList<>();
 
     private List<Location> positions = new ArrayList<>();
@@ -42,7 +43,6 @@ public class OneWayElytraListener implements Listener {
 
         Bukkit.getScheduler().runTaskTimer(oneWayElytra, () -> {
 
-            // Lokaler final Key für den Scheduler-Task
             final NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
 
             for (Player player : Bukkit.getOnlinePlayers()) {
@@ -100,13 +100,10 @@ public class OneWayElytraListener implements Listener {
                             .getRelative(BlockFace.DOWN)
                             .getType()
                             .isAir()) {
-
                         player.setGliding(false);
                         playersBoosted.remove(player);
 
-                        Bukkit.getScheduler().runTaskLater(
-                                oneWayElytra,
-                                () -> {
+                        Bukkit.getScheduler().runTaskLater(oneWayElytra, () -> {
                                     playersFlying.remove(player);
                                     player.setAllowFlight(false);
                                     ItemStack landingChest = player.getInventory().getChestplate();
@@ -123,6 +120,41 @@ public class OneWayElytraListener implements Listener {
             }
 
         }, 0, 3);
+    }
+
+    @EventHandler
+    public void onMove(PlayerMoveEvent event) {
+        Player player = event.getPlayer();
+        Location from = event.getFrom();
+        Location to = event.getTo();
+
+        if (to == null || (from.getBlockX() == to.getBlockX() && from.getBlockY() == to.getBlockY() && from.getBlockZ() == to.getBlockZ())) return;
+
+        if (playersFlying.contains(player)
+                && worldguardHook != null
+                && !worldguardHook.isEntryAllowed(player, to)) {
+
+            // 👉 HIER ist der richtige Ort
+            playersFlying.remove(player);
+            playersFalling.add(player);
+
+            player.setGliding(false);
+            player.setFlying(false);
+            player.setAllowFlight(false);
+
+            player.setFallDistance(0f);
+            player.setVelocity(new Vector(0, 0, 0));
+            player.setFireTicks(0);
+
+            event.setTo(from);
+
+            // optional: Schutzfenster starten (wichtig!)
+            Bukkit.getScheduler().runTaskLater(oneWayElytra, () -> {
+                playersFalling.remove(player);
+            }, 20L);
+            //TODO: MESSAGE STRING
+            ActionBar.send(player, "§cDu darfst hier nicht hineinfliegen!");
+        }
     }
 
     @EventHandler
@@ -198,11 +230,11 @@ public class OneWayElytraListener implements Listener {
     public void onEntityDamage(EntityDamageEvent event){
         if(event.getEntityType() == EntityType.PLAYER){
             Player player = (Player) event.getEntity();
-            if(playersFlying.contains(event.getEntity())){
-                if(event.getCause() == EntityDamageEvent.DamageCause.FALL){
+            if(playersFlying.contains(player) || playersFalling.contains(player)){
+                if(event.getCause().equals(EntityDamageEvent.DamageCause.FALL)
+                        || event.getCause().equals(EntityDamageEvent.DamageCause.FLY_INTO_WALL)){
                     event.setCancelled(true);
-                } else if(event.getCause() == EntityDamageEvent.DamageCause.FLY_INTO_WALL){
-                    event.setCancelled(true);
+                    player.setFallDistance(0f);
                 }
             }
         }

--- a/src/main/java/de/jugglegaming/oneWayElytra/listeners/OneWayElytraListener.java
+++ b/src/main/java/de/jugglegaming/oneWayElytra/listeners/OneWayElytraListener.java
@@ -19,9 +19,9 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.util.Vector;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 public class OneWayElytraListener implements Listener {
 
@@ -39,14 +39,18 @@ public class OneWayElytraListener implements Listener {
         this.oneWayElytra = oneWayElytra;
         this.worldguardHook = worldguardHook;
         this.radius = oneWayElytra.getFileManager().getConfig().getInt("radius");
+
         Bukkit.getScheduler().runTaskTimer(oneWayElytra, () -> {
+
+            // Lokaler final Key für den Scheduler-Task
+            final NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
 
             for (Player player : Bukkit.getOnlinePlayers()) {
 
-                boolean wgAllowed = false;
+                boolean wgStartAllowed = false;
 
                 if (worldguardHook != null) {
-                    wgAllowed = worldguardHook.canFly(player);
+                    wgStartAllowed = worldguardHook.canStart(player);
                 }
 
                 boolean inRadiusArea =
@@ -57,10 +61,13 @@ public class OneWayElytraListener implements Listener {
                 ItemStack chestplate = player.getInventory().getChestplate();
                 if (chestplate != null && chestplate.hasItemMeta()) {
                     PersistentDataContainer container = chestplate.getItemMeta().getPersistentDataContainer();
-                    NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
                     if (container.has(key, PersistentDataType.BYTE)) {
                         hasTaggedElytra = true;
                     }
+                }
+
+                if (hasTaggedElytra && worldguardHook != null && !worldguardHook.isItemAllowed(player)) {
+                    hasTaggedElytra = false;
                 }
 
                 if (isAllowedToFly(player)
@@ -77,7 +84,7 @@ public class OneWayElytraListener implements Listener {
                     }
                 }
 
-                if (!(wgAllowed || inRadiusArea || hasTaggedElytra)
+                if (!(wgStartAllowed || inRadiusArea || hasTaggedElytra)
                         && !playersFlying.contains(player)
                         && (player.getGameMode() == GameMode.SURVIVAL
                         || player.getGameMode() == GameMode.ADVENTURE)) {
@@ -105,12 +112,11 @@ public class OneWayElytraListener implements Listener {
                                     ItemStack landingChest = player.getInventory().getChestplate();
                                     if (landingChest != null && landingChest.hasItemMeta()) {
                                         PersistentDataContainer container = landingChest.getItemMeta().getPersistentDataContainer();
-                                        NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
                                         if (container.has(key, PersistentDataType.BYTE)) {
                                             player.getInventory().setChestplate(null);
                                         }
                                     }
-                                },5
+                                }, 5
                         );
                     }
                 }
@@ -136,7 +142,6 @@ public class OneWayElytraListener implements Listener {
         }
     }
 
-    // TODO: REMOVE BEFORE RELEASE
     @EventHandler
     public void onElytraItem(PlayerToggleFlightEvent event){
         Player player = event.getPlayer();
@@ -150,7 +155,7 @@ public class OneWayElytraListener implements Listener {
                 ItemStack itemStack = player.getInventory().getChestplate();
                 ItemMeta meta = itemStack.getItemMeta();
                 PersistentDataContainer dataContainer = meta.getPersistentDataContainer();
-                NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
+                final NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
                 if (dataContainer.has(key, PersistentDataType.BYTE)) {
                     player.sendMessage("JO");
                 } else {
@@ -163,9 +168,9 @@ public class OneWayElytraListener implements Listener {
     }
 
     public boolean isAllowedToFly(Player player) {
-        boolean wgAllowed = false;
+        boolean wgStartAllowed = false;
         if (worldguardHook != null) {
-            wgAllowed = worldguardHook.canFly(player);
+            wgStartAllowed = worldguardHook.canStart(player);
         }
         boolean inRadiusArea = oneWayElytra.getRadiusManager().isInAnyArea(player.getLocation());
         boolean hasTaggedElytra = false;
@@ -174,14 +179,18 @@ public class OneWayElytraListener implements Listener {
 
         if (chestplate != null && chestplate.hasItemMeta()) {
             PersistentDataContainer container = chestplate.getItemMeta().getPersistentDataContainer();
-            NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
+            final NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
             if (container.has(key, PersistentDataType.BYTE)) {
                 hasTaggedElytra = true;
             }
         }
 
+        if (hasTaggedElytra && worldguardHook != null && !worldguardHook.isItemAllowed(player)) {
+            hasTaggedElytra = false;
+        }
+
         if (hasTaggedElytra) return true;
-        return wgAllowed || inRadiusArea;
+        return wgStartAllowed || inRadiusArea;
     }
 
 
@@ -233,7 +242,6 @@ public class OneWayElytraListener implements Listener {
         }
     }
 
-    //Deny interaction with chestplate if player is flying
     @EventHandler
     public void onPlayerInteract(PlayerInteractEvent event) {
         Player player = event.getPlayer();
@@ -241,7 +249,7 @@ public class OneWayElytraListener implements Listener {
         if(playersFlying.contains(player)){
             if (chestplate != null && chestplate.hasItemMeta()) {
                 PersistentDataContainer container = chestplate.getItemMeta().getPersistentDataContainer();
-                NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
+                final NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
                 if (container.has(key, PersistentDataType.BYTE)) {
                     event.setCancelled(true);
                 }
@@ -249,17 +257,16 @@ public class OneWayElytraListener implements Listener {
         }
     }
 
-    //Deny interaction with onewayelytra if player is flying
     @EventHandler
     public void onItemClick(InventoryClickEvent event){
         if (!(event.getWhoClicked() instanceof Player)) return;
         Player player = (Player) event.getWhoClicked();
         if(playersFlying.contains(player)){
+            final NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
             if (event.getSlotType() == InventoryType.SlotType.ARMOR) {
                 ItemStack current = event.getCurrentItem();
                 if (current != null && current.hasItemMeta()) {
                     PersistentDataContainer container = current.getItemMeta().getPersistentDataContainer();
-                    NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
                     if (container.has(key, PersistentDataType.BYTE)) {
                         event.setCancelled(true);
                     }
@@ -269,7 +276,6 @@ public class OneWayElytraListener implements Listener {
                 ItemStack current = event.getCurrentItem();
                 if (current != null && current.hasItemMeta()) {
                     PersistentDataContainer container = current.getItemMeta().getPersistentDataContainer();
-                    NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
                     if (container.has(key, PersistentDataType.BYTE)) {
                         event.setCancelled(true);
                     }

--- a/src/main/java/de/jugglegaming/oneWayElytra/listeners/OneWayElytraListener.java
+++ b/src/main/java/de/jugglegaming/oneWayElytra/listeners/OneWayElytraListener.java
@@ -13,6 +13,10 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityToggleGlideEvent;
 import org.bukkit.event.player.*;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -58,6 +62,19 @@ public class OneWayElytraListener implements Listener {
                             .getBoolean("adventure"))) {
 
                         player.setAllowFlight(true);
+                    }
+                }
+                if(player.getInventory().getChestplate() != null) {
+                    player.sendMessage("HAS CHESTPLATE");
+                    ItemStack itemStack = player.getInventory().getChestplate();
+                    ItemMeta meta = itemStack.getItemMeta();
+                    PersistentDataContainer dataContainer = meta.getPersistentDataContainer();
+                    NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
+                    if (dataContainer.has(key, PersistentDataType.STRING)) {
+                        player.sendMessage("JO");
+                        player.
+                    } else {
+                        player.sendMessage("NOPE");
                     }
                 }
 
@@ -109,6 +126,34 @@ public class OneWayElytraListener implements Listener {
                 Bukkit.getScheduler().runTaskLater(oneWayElytra, () -> {
                     player.setAllowFlight(false);
                 }, 1L);
+            }
+        }
+
+
+    }
+
+    @EventHandler
+    public void onElytraItem(PlayerToggleFlightEvent event){
+        Player player = event.getPlayer();
+        //TODO: SURVIVAL AND ADVENTURE MODE ONLY
+        if(player.getGameMode().equals(GameMode.CREATIVE)) {
+            player.sendMessage("CREATIVE MODE");
+        } else {
+            event.setCancelled(true);
+            player.sendMessage("CANCELLED");
+            if(player.getInventory().getChestplate() != null){
+                player.sendMessage("HAS CHESTPLATE");
+                ItemStack itemStack = player.getInventory().getChestplate();
+                ItemMeta meta = itemStack.getItemMeta();
+                PersistentDataContainer dataContainer = meta.getPersistentDataContainer();
+                NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
+                if (dataContainer.has(key, PersistentDataType.STRING)) {
+                    player.sendMessage("JO");
+                } else {
+                    player.sendMessage("NOPE");
+                }
+            } else {
+                player.sendMessage("NO CHESTPLATE");
             }
         }
 

--- a/src/main/java/de/jugglegaming/oneWayElytra/listeners/OneWayElytraListener.java
+++ b/src/main/java/de/jugglegaming/oneWayElytra/listeners/OneWayElytraListener.java
@@ -134,7 +134,6 @@ public class OneWayElytraListener implements Listener {
                 && worldguardHook != null
                 && !worldguardHook.isEntryAllowed(player, to)) {
 
-            // 👉 HIER ist der richtige Ort
             playersFlying.remove(player);
             playersFalling.add(player);
 
@@ -144,16 +143,24 @@ public class OneWayElytraListener implements Listener {
 
             player.setFallDistance(0f);
             player.setVelocity(new Vector(0, 0, 0));
-            player.setFireTicks(0);
 
             event.setTo(from);
+            //TODO: MESSAGE STRING
 
-            // optional: Schutzfenster starten (wichtig!)
+            ActionBar.send(player, "§cDu darfst hier nicht hineinfliegen!");
+        }
+        if (playersFalling.contains(player) && player.isOnGround()) {
+            ItemStack chestplate = player.getInventory().getChestplate();
+            if (chestplate != null && chestplate.hasItemMeta()) {
+                PersistentDataContainer container = chestplate.getItemMeta().getPersistentDataContainer();
+                final NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
+                if (container.has(key, PersistentDataType.BYTE)) {
+                    player.getInventory().setChestplate(null);
+                }
+            }
             Bukkit.getScheduler().runTaskLater(oneWayElytra, () -> {
                 playersFalling.remove(player);
-            }, 20L);
-            //TODO: MESSAGE STRING
-            ActionBar.send(player, "§cDu darfst hier nicht hineinfliegen!");
+            }, 1L);
         }
     }
 
@@ -171,30 +178,14 @@ public class OneWayElytraListener implements Listener {
                     player.setAllowFlight(false);
                 }, 1L);
             }
-        }
-    }
-
-    @EventHandler
-    public void onElytraItem(PlayerToggleFlightEvent event){
-        Player player = event.getPlayer();
-        if(player.getGameMode().equals(GameMode.CREATIVE)) {
-            player.sendMessage("CREATIVE MODE");
-        } else {
-            event.setCancelled(true);
-            player.sendMessage("CANCELLED");
             if(player.getInventory().getChestplate() != null){
-                player.sendMessage("HAS CHESTPLATE");
                 ItemStack itemStack = player.getInventory().getChestplate();
                 ItemMeta meta = itemStack.getItemMeta();
                 PersistentDataContainer dataContainer = meta.getPersistentDataContainer();
                 final NamespacedKey key = new NamespacedKey(oneWayElytra, "onewayelytra-elytraitem");
                 if (dataContainer.has(key, PersistentDataType.BYTE)) {
-                    player.sendMessage("JO");
-                } else {
-                    player.sendMessage("NOPE");
+                    event.setCancelled(true);
                 }
-            } else {
-                player.sendMessage("NO CHESTPLATE");
             }
         }
     }
@@ -232,7 +223,8 @@ public class OneWayElytraListener implements Listener {
             Player player = (Player) event.getEntity();
             if(playersFlying.contains(player) || playersFalling.contains(player)){
                 if(event.getCause().equals(EntityDamageEvent.DamageCause.FALL)
-                        || event.getCause().equals(EntityDamageEvent.DamageCause.FLY_INTO_WALL)){
+                        || event.getCause().equals(EntityDamageEvent.DamageCause.FLY_INTO_WALL)
+                        || event.getCause().equals(EntityDamageEvent.DamageCause.CONTACT)){
                     event.setCancelled(true);
                     player.setFallDistance(0f);
                 }

--- a/src/main/java/de/jugglegaming/oneWayElytra/listeners/OneWayElytraListener.java
+++ b/src/main/java/de/jugglegaming/oneWayElytra/listeners/OneWayElytraListener.java
@@ -146,7 +146,6 @@ public class OneWayElytraListener implements Listener {
 
             event.setTo(from);
             //TODO: MESSAGE STRING
-
             ActionBar.send(player, "§cDu darfst hier nicht hineinfliegen!");
         }
         if (playersFalling.contains(player) && player.isOnGround()) {

--- a/src/main/java/de/jugglegaming/oneWayElytra/utils/ActionBar.java
+++ b/src/main/java/de/jugglegaming/oneWayElytra/utils/ActionBar.java
@@ -2,8 +2,6 @@ package de.jugglegaming.oneWayElytra.utils;
 
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.BaseComponent;
-import net.md_5.bungee.api.chat.ComponentBuilder;
-import net.md_5.bungee.api.chat.KeybindComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.entity.Player;
 

--- a/src/main/java/de/jugglegaming/oneWayElytra/utils/WorldguardFlags.java
+++ b/src/main/java/de/jugglegaming/oneWayElytra/utils/WorldguardFlags.java
@@ -18,24 +18,40 @@ public class WorldguardFlags extends FlagValueChangeHandler {
         super(session, flag);
     }
 
-    public static StateFlag ONEWAYELYTRA ;
+    public static StateFlag OWE_START ;
+    public static StateFlag OWE_ENTRY ;
+    public static StateFlag OWE_ITEM ;
 
     public static void load(){
         FlagRegistry registry = WorldGuard.getInstance().getFlagRegistry();
         try {
-            // create a flag with the name "my-custom-flag", defaulting to true
-            StateFlag flag = new StateFlag("onewayelytra", false);
-            registry.register(flag);
-            ONEWAYELYTRA = flag; // only set our field if there was no error
+            StateFlag startFlag = new StateFlag("owe-start", false);
+            registry.register(startFlag);
+            OWE_START = startFlag;
         } catch (FlagConflictException e) {
-            // some other plugin registered a flag by the same name already.
-            // you can use the existing flag, but this may cause conflicts - be sure to check type
-            Flag<?> existing = registry.get("my-custom-flag");
+            Flag<?> existing = registry.get("owe-start");
             if (existing instanceof StateFlag) {
-                ONEWAYELYTRA = (StateFlag) existing;
-            } else {
-                // types don't match - this is bad news! some other plugin conflicts with you
-                // hopefully this never actually happens
+                OWE_START = (StateFlag) existing;
+            }
+        }
+        try {
+            StateFlag entryFlag = new StateFlag("owe-entry", true);
+            registry.register(entryFlag);
+            OWE_ENTRY = entryFlag;
+        } catch (FlagConflictException e) {
+            Flag<?> existing = registry.get("owe-entry");
+            if (existing instanceof StateFlag) {
+                OWE_ENTRY = (StateFlag) existing;
+            }
+        }
+        try {
+            StateFlag itemFlag = new StateFlag("owe-item", true);
+            registry.register(itemFlag);
+            OWE_ITEM = itemFlag;
+        } catch (FlagConflictException e) {
+            Flag<?> existing = registry.get("owe-item");
+            if (existing instanceof StateFlag) {
+                OWE_ITEM = (StateFlag) existing;
             }
         }
     }

--- a/src/main/java/de/jugglegaming/oneWayElytra/utils/WorldguardFlags.java
+++ b/src/main/java/de/jugglegaming/oneWayElytra/utils/WorldguardFlags.java
@@ -32,6 +32,8 @@ public class WorldguardFlags extends FlagValueChangeHandler {
             Flag<?> existing = registry.get("owe-start");
             if (existing instanceof StateFlag) {
                 OWE_START = (StateFlag) existing;
+            } else {
+                throw new IllegalStateException("WorldGuard flag 'owe-start' exists with incompatible type", e);
             }
         }
         try {
@@ -42,6 +44,8 @@ public class WorldguardFlags extends FlagValueChangeHandler {
             Flag<?> existing = registry.get("owe-entry");
             if (existing instanceof StateFlag) {
                 OWE_ENTRY = (StateFlag) existing;
+            } else {
+                throw new IllegalStateException("WorldGuard flag 'owe-entry' exists with incompatible type", e);
             }
         }
         try {
@@ -52,6 +56,8 @@ public class WorldguardFlags extends FlagValueChangeHandler {
             Flag<?> existing = registry.get("owe-item");
             if (existing instanceof StateFlag) {
                 OWE_ITEM = (StateFlag) existing;
+            } else {
+                throw new IllegalStateException("WorldGuard flag 'owe-item' exists with incompatible type", e);
             }
         }
     }

--- a/src/main/java/de/jugglegaming/oneWayElytra/utils/WorldguardHook.java
+++ b/src/main/java/de/jugglegaming/oneWayElytra/utils/WorldguardHook.java
@@ -23,7 +23,7 @@ public class WorldguardHook {
     }
 
     public boolean isEntryAllowed(Player player, Location location) {
-        com.sk89q.worldedit.util.Location loc = BukkitAdapter.adapt(player.getLocation());
+        com.sk89q.worldedit.util.Location loc = BukkitAdapter.adapt(location);
         RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
         RegionQuery query = container.createQuery();
         ApplicableRegionSet set = query.getApplicableRegions(loc);

--- a/src/main/java/de/jugglegaming/oneWayElytra/utils/WorldguardHook.java
+++ b/src/main/java/de/jugglegaming/oneWayElytra/utils/WorldguardHook.java
@@ -12,27 +12,35 @@ import org.bukkit.entity.Player;
 public class WorldguardHook {
 
     public boolean canFly(Player player) {
-
-        com.sk89q.worldedit.util.Location loc =
-                BukkitAdapter.adapt(player.getLocation());
-
-        RegionContainer container =
-                WorldGuard.getInstance()
-                        .getPlatform()
-                        .getRegionContainer();
-
+        com.sk89q.worldedit.util.Location loc = BukkitAdapter.adapt(player.getLocation());
+        RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
         RegionQuery query = container.createQuery();
+        ApplicableRegionSet set = query.getApplicableRegions(loc);
+        LocalPlayer localPlayer = WorldGuardPlugin.inst().wrapPlayer(player);
 
-        ApplicableRegionSet set =
-                query.getApplicableRegions(loc);
-
-        LocalPlayer localPlayer =
-                WorldGuardPlugin.inst().wrapPlayer(player);
-
-        return set.testState(
-                localPlayer,
-                WorldguardFlags.ONEWAYELYTRA
-        );
+        return set.testState(localPlayer, WorldguardFlags.OWE_START);
     }
+
+    public boolean canEnter(Player player) {
+        com.sk89q.worldedit.util.Location loc = BukkitAdapter.adapt(player.getLocation());
+        RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
+        RegionQuery query = container.createQuery();
+        ApplicableRegionSet set = query.getApplicableRegions(loc);
+        LocalPlayer localPlayer = WorldGuardPlugin.inst().wrapPlayer(player);
+
+        return set.testState(localPlayer, WorldguardFlags.OWE_ENTRY);
+    }
+
+    public boolean canUseOweItem(Player player) {
+        com.sk89q.worldedit.util.Location loc = BukkitAdapter.adapt(player.getLocation());
+        RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
+        RegionQuery query = container.createQuery();
+        ApplicableRegionSet set = query.getApplicableRegions(loc);
+        LocalPlayer localPlayer = WorldGuardPlugin.inst().wrapPlayer(player);
+
+        return set.testState(localPlayer, WorldguardFlags.OWE_ITEM);
+    }
+
+
 
 }

--- a/src/main/java/de/jugglegaming/oneWayElytra/utils/WorldguardHook.java
+++ b/src/main/java/de/jugglegaming/oneWayElytra/utils/WorldguardHook.java
@@ -7,11 +7,12 @@ import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
 import com.sk89q.worldguard.protection.ApplicableRegionSet;
 import com.sk89q.worldguard.protection.regions.RegionContainer;
 import com.sk89q.worldguard.protection.regions.RegionQuery;
+import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
 public class WorldguardHook {
 
-    public boolean canFly(Player player) {
+    public boolean canStart(Player player) {
         com.sk89q.worldedit.util.Location loc = BukkitAdapter.adapt(player.getLocation());
         RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
         RegionQuery query = container.createQuery();
@@ -21,7 +22,7 @@ public class WorldguardHook {
         return set.testState(localPlayer, WorldguardFlags.OWE_START);
     }
 
-    public boolean canEnter(Player player) {
+    public boolean isEntryAllowed(Player player, Location location) {
         com.sk89q.worldedit.util.Location loc = BukkitAdapter.adapt(player.getLocation());
         RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
         RegionQuery query = container.createQuery();
@@ -31,7 +32,7 @@ public class WorldguardHook {
         return set.testState(localPlayer, WorldguardFlags.OWE_ENTRY);
     }
 
-    public boolean canUseOweItem(Player player) {
+    public boolean isItemAllowed(Player player) {
         com.sk89q.worldedit.util.Location loc = BukkitAdapter.adapt(player.getLocation());
         RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
         RegionQuery query = container.createQuery();

--- a/src/main/resources/DE.yml
+++ b/src/main/resources/DE.yml
@@ -2,8 +2,8 @@
 ## OneWayElytra | DEyml
 ##
 
-# Do not change anything unless you know what you are doing!
-config-version: 2
+# Do not change the config-version unless you know what you are doing!
+config-version: 3
 
 prefix: '&5OWE &fÂ»'
 commandDenied: '&cDu darfst diesen Befehl nicht verwenden'
@@ -12,6 +12,7 @@ locationRemoved: '&7Du hast die &7die Position &e%location% &7erfolgreich &cgelÃ
 locationNotFound: '&cDiese Position gibt es nicht'
 radiusSet: '&7Du hast den Radius von &e%location% &7auf &e%radius% &7gesetzt.'
 wrongArgs: '&cDu hast falsche Argumente verwendet. Verwende &4/onewayelytra&c.'
+areaEntryNotAllowed: '&cDu darfst innerhalb dieses Bereichs nicht fliegen!'
 boostMessage: '&7Klicken, um einen Boost zu erhalten.'
 world: 'Welt'
 radius: 'Radius'

--- a/src/main/resources/EN.yml
+++ b/src/main/resources/EN.yml
@@ -2,8 +2,8 @@
 ## OneWayElytra | EN.yml
 ##
 
-# Do not change anything unless you know what you are doing!
-config-version: 2
+# Do not change the config-version unless you know what you are doing!
+config-version: 3
 
 prefix: '&5OWE &f»'
 commandDenied: '&cYou are not allowed to execute this command!'
@@ -12,6 +12,7 @@ locationRemoved: '&7You &cdeleted &7the location &e%location% &7successfully&7.'
 locationNotFound: '&cThis location does not exist!'
 radiusSet: '&7You set the radius to &e%radius%&7 &7for location &e%location%&7.'
 wrongArgs: '&cYou tried to use wrong arguments. Please check &4/onewayelytra&c.'
+areaEntryNotAllowed: '&cYou are not allowed to enter this area while flying!'
 boostMessage: '&7Click into the air to get a boost!'
 world: 'World'
 radius: 'Radius'

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: OneWayElytra
-version: '1.1.2'
+version: '1.2.0-beta1'
 main: de.jugglegaming.oneWayElytra.OneWayElytra
 author: JuggleGaming
 api-version: '26.1.2'


### PR DESCRIPTION
### New features
- Added the ability to use a custom tagged chestplate-item as an owe.

### This is a beta version! Do not use in production!
This beta features the first tests for the new owe-item. To be able to test the new Item just use `/owe tag add` to add the tag to an item, that is inside your chestplate slot. When the tag is added, you can fly into the air where ever you want. This item can be given to other players. Atm it isn't possible to set a tag for another player. This Command ist mostly for testing and might be removed at a later state. With `/owe tag remove` the tag can be removed again. This command applies to the executors chestplate-slot only.

To disable the ability to start flying everywhere you can set the worldguard-flag `OWE-ITEM` to `false`. To deny entry into an area while using your owe set the flag `OWE-ENTRY` to `false`.

## Breaking changes
The worldguard-flag to enable the ability to fly without an owe-item (as before) has been renamed to `OWE-START` (before: `ONEWAYELYTRA`). Please check wether this results any issues and if you have to change the flag.

### Information
Worldguard version needed: 7.0.16


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Version 1.2.0-beta1**

* **New Features**
  * Beta feature: Tag chestplate items using `/owe tag add/remove/info` to enable "owe" flight behavior
  * Three new WorldGuard flags for granular control: OWE-START, OWE-ENTRY, and OWE-ITEM

* **Breaking Changes**
  * WorldGuard flag `ONEWAYELYTRA` renamed to `OWE-START`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->